### PR TITLE
'morePics' added to $newResult array within fetch()

### DIFF
--- a/src/InstagramWithoutApi/Fetch.php
+++ b/src/InstagramWithoutApi/Fetch.php
@@ -256,7 +256,19 @@ class Fetch {
 							);
 
 							if($base64images) $newResult['image'] = base64_encode(file_get_contents(@  $items[$i]['node']['display_url']));
-
+							if(@ $items[$i]['node']['edge_sidecar_to_children']){
+								$total_sidecars = count(@ $items[$i]['node']['edge_sidecar_to_children']['edges']);
+								// start index @ 1 because 0 is the first image - aka imageUrl above.
+								for($ii = 1; $ii < $total_sidecars; $ii++){
+									if($items[$i]['node']['edge_sidecar_to_children']['edges'][$ii]['node']['__typename'] == 'GraphImage' 
+										&& $items[$i]['node']['edge_sidecar_to_children']['edges'][$ii]['node']['display_url']){
+										$newResult['morePics'][] = [
+											'imageUrl' => @ $items[$i]['node']['edge_sidecar_to_children']['edges'][$ii]['node']['display_url'],
+											'image' => $base64images ? base64_encode(file_get_contents(@ $items[$i]['node']['edge_sidecar_to_children']['edges'][$ii]['node']['display_url'])) : ''
+										];
+									}
+								}
+							}
 							$temp[] = $newResult;
 							
 						}


### PR DESCRIPTION
Some posts have more than 1 picture, and I needed to grab all the pictures for the posts, if it had more. So this is what I've come up with.

I'm sure something like this could be added to your 2 new functions, but I have not taken a look at the array returned from those paths to confirm.

I will probably be tweaking this some more to allow us to base64_decode() the images and save them on our system so its not as heavy in the source. Will update your project when I am able to confirm that is working.

````json
[
  {
    "id": "2696840872190940431",
    "time": 1635708506,
    "imageUrl": "https://scontent-lcy1-1.cdninstagram.com/v/t51.2885-15/e35/p1080x1080/249938862_1214260935751176_32...",
    "likes": 18,
    "comments": 0,
    "link": "https://www.instagram.com/p/CVtGnwashUP/",
    "text": "#helloworld #domain #check",
    "image": "/9j/4AAQSkZJRgABAQAAAQABAAD/7QB8UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAGA.............",
    "morePics": [
        {
            "imageUrl": "https://scontent-lcy1-1.cdninstagram.com/v/t51.2885-15/e35...............",
            "image": "/9j/4AAQSkZJRgABAQAAAQABAAD/7QB8UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAGA............."
        },
        {
            "imageUrl": "https://scontent-lcy1-1.cdninstagram.com/v/t51.2885-15/e35...............",
            "image": "/9j/4AAQSkZJRgABAQAAAQABAAD/7QB8UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAGA............."
        }
    ]
  }
]
````

Thanks for the awesome class!